### PR TITLE
gsi: Add privapp permissions for me.phh.treble.app

### DIFF
--- a/device.mk
+++ b/device.mk
@@ -15,6 +15,10 @@ PRODUCT_COPY_FILES += \
     $(DEVICE_PATH)/init/treble-post-fs.sh:$(TARGET_COPY_OUT_SYSTEM)/bin/treble-post-fs.sh \
     $(DEVICE_PATH)/init/treble-prop-handler.sh:$(TARGET_COPY_OUT_SYSTEM)/bin/treble-prop-handler.sh
 
+# Privapp permissions
+PRODUCT_COPY_FILES += \
+	$(DEVICE_PATH)/privapp-permissions-me.phh.treble.app.xml:$(TARGET_COPY_OUT_SYSTEM)/etc/permissions/privapp-permissions-me.phh.treble.app.xml
+
 PRODUCT_PACKAGES += \
     resetprop_sys
 

--- a/privapp-permissions-me.phh.treble.app.xml
+++ b/privapp-permissions-me.phh.treble.app.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8"?>
+<permissions>
+    <privapp-permissions package="me.phh.treble.app">
+	    <permission name="android.permission.INSTALL_PACKAGES"/>
+	    <permission name="android.permission.INTERACT_ACROSS_USERS"/>
+    </privapp-permissions>
+</permissions>


### PR DESCRIPTION
I'm testing the Lineage 21 light vS build on Poco M6 Pro (emerald). It gets stuck on the Lineage logo during boot. Here are the logs: https://gist.github.com/Litnareso/d0f5f3388a7e29bffe5898222975d705

After setting `ro.control_privapp_permissions` to `permissive`, I was able to boot into the system. I reverted it back to `log` and then tried setting privapp permissions for the app as in TrebleDroid device tree: https://github.com/TrebleDroid/device_phh_treble/blob/android-14.0/privapp-permissions-me.phh.treble.app.xml . That worked too. I'm not sure if all the permissions are needed, so I included only those that appeared in the logs.


